### PR TITLE
修复添加多个fragment时，返回键无效问题

### DIFF
--- a/src/com/xmy/fragmenthandlebackdemo/BackHandledFragment.java
+++ b/src/com/xmy/fragmenthandlebackdemo/BackHandledFragment.java
@@ -9,9 +9,9 @@ public abstract class BackHandledFragment extends Fragment {
 	protected BackHandledInterface mBackHandledInterface;
 	
 	/**
-	 * ËùÓĞ¼Ì³ĞBackHandledFragmentµÄ×ÓÀà¶¼½«ÔÚÕâ¸ö·½·¨ÖĞÊµÏÖÎïÀíBack¼ü°´ÏÂºóµÄÂß¼­
-	 * FragmentActivity²¶×½µ½ÎïÀí·µ»Ø¼üµã»÷ÊÂ¼şºó»áÊ×ÏÈÑ¯ÎÊFragmentÊÇ·ñÏû·Ñ¸ÃÊÂ¼ş
-	 * Èç¹ûÃ»ÓĞFragmentÏûÏ¢Ê±FragmentActivity×Ô¼º²Å»áÏû·Ñ¸ÃÊÂ¼ş
+	 * æ‰€æœ‰ç»§æ‰¿BackHandledFragmentçš„å­ç±»éƒ½å°†åœ¨è¿™ä¸ªæ–¹æ³•ä¸­å®ç°ç‰©ç†Backé”®æŒ‰ä¸‹åçš„é€»è¾‘
+	 * FragmentActivityæ•æ‰åˆ°ç‰©ç†è¿”å›é”®ç‚¹å‡»äº‹ä»¶åä¼šé¦–å…ˆè¯¢é—®Fragmentæ˜¯å¦æ¶ˆè´¹è¯¥äº‹ä»¶
+	 * å¦‚æœæ²¡æœ‰Fragmentæ¶ˆæ¯æ—¶FragmentActivityè‡ªå·±æ‰ä¼šæ¶ˆè´¹è¯¥äº‹ä»¶
 	 */
 	protected abstract boolean onBackPressed();
 	
@@ -28,8 +28,17 @@ public abstract class BackHandledFragment extends Fragment {
 	@Override
 	public void onStart() {
 		super.onStart();
-		//¸æËßFragmentActivity£¬µ±Ç°FragmentÔÚÕ»¶¥
+		//å‘Šè¯‰FragmentActivityï¼Œå½“å‰Fragmentåœ¨æ ˆé¡¶
 		mBackHandledInterface.setSelectedFragment(this);
+	}
+	
+	/**
+	 * å‡ºé˜Ÿ
+	 **/
+	@Override
+	public void onStop(){
+		super.onStop();
+		mBackHandledInterface.popBackSelectedFragment(this);
 	}
 	
 }

--- a/src/com/xmy/fragmenthandlebackdemo/BackHandledInterface.java
+++ b/src/com/xmy/fragmenthandlebackdemo/BackHandledInterface.java
@@ -3,4 +3,6 @@ package com.xmy.fragmenthandlebackdemo;
 public interface BackHandledInterface {
 
 	public abstract void setSelectedFragment(BackHandledFragment selectedFragment);
+	
+	public void popBackSelectedFragment(BackHandledFragment selectedFragment);
 }

--- a/src/com/xmy/fragmenthandlebackdemo/MainActivity.java
+++ b/src/com/xmy/fragmenthandlebackdemo/MainActivity.java
@@ -13,6 +13,7 @@ import android.widget.Button;
 public class MainActivity extends FragmentActivity implements BackHandledInterface{
 
 	private BackHandledFragment mBackHandedFragment;
+	private List<BackHandledFragment> mBackHandedList=new ArrayList<BackHandledFragment>();
 	private boolean hadIntercept;
 	
 	private Button mBtn;
@@ -57,7 +58,18 @@ public class MainActivity extends FragmentActivity implements BackHandledInterfa
 
 	@Override
 	public void setSelectedFragment(BackHandledFragment selectedFragment) {
+		mBackHandedList.add(selectedFragment);
 		this.mBackHandedFragment = selectedFragment;
+	}
+	
+	@Override
+	public void popBackSelectedFragment(BackHandledFragment selectedFragment) {
+		mBackHandedList.remove(selectedFragment);
+		int size=mBackHandedList.size();
+		if(size>0){
+		    this.mBackHandedFragment = mBackHandedList.get(size-1);
+		}
+		
 	}
 	
 	@Override


### PR DESCRIPTION
哥们，这个代码有个问题哈。
fragment的生命周期中onStart只会在第一次启动或者被销毁后重新添加才会被调用，如果通过ADD方式添加多个fragment，每次按返回键，不会再调底下fragment的onStart方法，mBackHandedFragment肯定是最后被添加的那个，永远都不会更新了。
有个解决办法，在activity中建一个队列，每次onStart的时候，将fragment加入队列，onStop的时候，将fragment从队列中移除，同时，取队列中最后一个元素做为当前可视部分的fragment。
